### PR TITLE
clarify UA may be hidden when fully obscured

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
     wgPublicList: "public-web-perf",
     implementationReportURI: "https://wpt.fyi/page-visibility/",
     // noLegacyStyle: true,
-    testSuiteURI: "https://w3c-test.org/page-visibility/"
+    testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/page-visibility",
+    caniuse: "pagevisibility"
     };
     </script>
   </head>
@@ -288,13 +289,9 @@
           </li>
         </ol>
         <p data-link-for="VisibilityState">
-          The user agent MAY return "<a>hidden</a>" if the window is fully obscured 
-          by an accessibility tool but the accessibility tool is not covering it.
-          To accommodate assistive technologies that are typically full screen
-          but still show a view of the page, when applicable, on getting, the
-          <a data-link-for="Document">visibilityState</a> attribute MAY return
-          "<a>visible</a>", instead of "<a>hidden</a>", when the user agent is
-          not minimized but is fully obscured by other applications.
+          When possible, if the user agent is fully obscured by another 
+          application, the <a>visibilityState</a> attribute SHOULD return 
+          "<a>hidden</a>", except if a view of the <var>doc</var> is displayed in an accessibility tool.
         </p>
       </section>
       <section data-dfn-for="Document" data-link-for="Document">

--- a/index.html
+++ b/index.html
@@ -288,6 +288,8 @@
           </li>
         </ol>
         <p data-link-for="VisibilityState">
+          The user agent MAY return "<a>hidden</a>" if the window is fully obscured 
+          by an accessibility tool but the accessibility tool is not covering it.
           To accommodate assistive technologies that are typically full screen
           but still show a view of the page, when applicable, on getting, the
           <a data-link-for="Document">visibilityState</a> attribute MAY return


### PR DESCRIPTION
Discussed in issue #34 and [TPAC 2017](https://www.w3.org/2017/11/07-webperf-minutes.html#item05).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/siusin/page-visibility/pull/38.html" title="Last updated on Jul 24, 2018, 3:56 PM GMT (38a9c9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/page-visibility/38/e735afc...siusin:38a9c9b.html" title="Last updated on Jul 24, 2018, 3:56 PM GMT (38a9c9b)">Diff</a>