### PR TITLE
Correct reference of Page Visibility to top level browsing context

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
     wgPublicList: "public-web-perf",
     implementationReportURI: "https://wpt.fyi/page-visibility/",
     // noLegacyStyle: true,
-    testSuiteURI: "https://w3c-test.org/page-visibility/"
+    testSuiteURI: "https://w3c-test.org/page-visibility/",
+    xref: 'web-platform'
     };
     </script>
   </head>
@@ -228,9 +229,9 @@
           run the <dfn>steps to determine the visibility state</dfn>:
         </p>
         <ol class="algorithm">
-          <li>Let <var>doc</var> be the <a>Document</a> of the <a>top level
-          browsing context</a>.
-          </li>
+          <li>Return "hidden" if the <a>context object</a>is not <a>fully active</a></li>
+          <li>Let <var>doc</var> be the <a>active document</a> of the <a>top level
+          browsing context</a> of the <a>context object</a>'s [=Document/browsing context=].</li>
           <li>If the <a>defaultView</a> of <var>doc</var> is <code>null</code>,
           return "<a data-lt="VisibilityState.hidden">hidden</a>".
           </li>


### PR DESCRIPTION
This should fix #41 

@rniwa @jyasskin, can you take a look?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toddreifsteck/page-visibility/pull/45.html" title="Last updated on Aug 19, 2019, 7:14 AM UTC (7784396)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/page-visibility/45/f663421...toddreifsteck:7784396.html" title="Last updated on Aug 19, 2019, 7:14 AM UTC (7784396)">Diff</a>