### PR TITLE
Allow a user agent to return hidden when obscured

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,8 @@
       </h2>
       <p>
         The <cite>Page Visibility API</cite> defines a means to
-        programmatically determine the <a>visibility state</a> of a top-level
-        browsing context, and to be notified if the <a>visibility state</a>
+        programmatically determine the <a>visibility state</a> of the <a>top-level
+        browsing context</a>, and to be notified if the <a>visibility state</a>
         changes. Without knowing the <a>visibility state</a> of a page, web
         developers have been designing web pages as if they are always
         <a>visible</a>. This not only results in higher machine resource
@@ -242,9 +242,6 @@
           <li>Return "hidden" if the <a>context object</a> is not [=Document/fully active=]</li>
           <li>Let |doc:Document| be the <a>active document</a> of the top level
           browsing context of the <a>context object</a>'s [=Document/browsing context=].</li>
-          <li>If the {{Document/defaultView}} of |doc| is `null`,
-          return {{VisibilityState["hidden"]}}.
-          </li>
           <li>Otherwise, return the {{VisibilityState}} value that best matches
           the <a>visibility state</a> of |doc|:
             <ol>

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
           run the <dfn>steps to determine the visibility state</dfn>:
         </p>
         <ol class="algorithm">
-          <li>Return "hidden" if the <a>context object</a>is not <a>fully active</a></li>
+          <li>Return "hidden" if the <a>context object</a> is not <a>fully active</a></li>
           <li>Let <var>doc</var> be the <a>active document</a> of the <a>top level
           browsing context</a> of the <a>context object</a>'s [=Document/browsing context=].</li>
           <li>If the <a>defaultView</a> of <var>doc</var> is <code>null</code>,
@@ -240,38 +240,35 @@
             <ol data-link-for="VisibilityState">
               <li>Return "<a>visible</a>" if:
                 <ol>
-                  <li>The user agent is not minimized and <var>doc</var> is the
-                  foreground tab.
-                  </li>
-                  <li>The user agent is fully obscured by an accessibility
-                  tool, like a magnifier, but a view of the <var>doc</var> is
-                  shown.
-                  </li>
+                  <li>The user agent has a screen reader attached to the <var>doc</var></li>
+                  <li>Any of the <var>doc</var>'s viewport contents are observable to the user</li>
                 </ol>
               </li>
               <li>Return "<a>hidden</a>" if:
                 <ol>
-                  <li>The user agent is minimized.
-                  </li>
-                  <li>The user agent is not minimized, but <var>doc</var> is on
-                  a background tab.
-                  </li>
-                  <li>The user agent is to <a>unload</a> <var>doc</var>.
-                  </li>
-                  <li>The Operating System lock screen is shown.
-                  </li>
+                  <li>The user agent is to <a>unload</a> <var>doc</var></li>
+                  <li>The <var>doc</var>'s viewport contents are not observable to the user</li>
                 </ol>
               </li>
             </ol>
           </li>
         </ol>
-        <p data-link-for="VisibilityState">
+        <div class="note">
+        <p>
           To accommodate assistive technologies that are typically full screen
           but still show a view of the page, when applicable, on getting, the
           <a data-link-for="Document">visibilityState</a> attribute MAY return
-          "<a>visible</a>", instead of "<a>hidden</a>", when the user agent is
+          <a>visible</a>, instead of <a>hidden</a>, when the user agent is
           not minimized but is fully obscured by other applications.
-        </p>
+          <p>
+          Examples of ways that <a>hidden</a> may be returned:
+          <ul>
+          <li>A tab is made into a background tab</li>
+          <li>The user agent is minimized</li>
+          <li>The user agent is moved off of the screen</li>
+          <li>The operating system's lock screen covers the user agent</li>
+          </ul>
+        </div>
       </section>
       <section data-dfn-for="Document" data-link-for="Document">
         <h3>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
     wgPublicList: "public-web-perf",
     implementationReportURI: "https://wpt.fyi/page-visibility/",
     // noLegacyStyle: true,
-    testSuiteURI: "https://w3c-test.org/page-visibility/"
+    testSuiteURI: "https://w3c-test.org/page-visibility/",
+    xref: 'web-platform'
     };
     </script>
   </head>
@@ -228,9 +229,9 @@
           run the <dfn>steps to determine the visibility state</dfn>:
         </p>
         <ol class="algorithm">
-          <li>Let <var>doc</var> be the <a>Document</a> of the <a>top level
-          browsing context</a>.
-          </li>
+          <li>Return "hidden" if the <a>context object</a>is not <a>fully active</a></li>
+          <li>Let <var>doc</var> be the <a>active document</a> of the <a>top level
+          browsing context</a> of the <a>context object</a>'s [=Document/browsing context=].</li>
           <li>If the <a>defaultView</a> of <var>doc</var> is <code>null</code>,
           return "<a data-lt="VisibilityState.hidden">hidden</a>".
           </li>


### PR DESCRIPTION
https://github.com/w3c/page-visibility/issues/34


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toddreifsteck/page-visibility/pull/46.html" title="Last updated on Sep 17, 2019, 7:32 AM UTC (1f1c068)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/page-visibility/46/f663421...toddreifsteck:1f1c068.html" title="Last updated on Sep 17, 2019, 7:32 AM UTC (1f1c068)">Diff</a>