### PR TITLE
Chore: export definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,40 +10,34 @@
     <script class='remove'>
     //make tidy happy
     var respecConfig = {
-    specStatus: 'ED',
-    shortName: 'page-visibility-2',
-    editors: [{
-      name: "Ilya Grigorik",
-      url: "https://www.igvita.com/",
-      mailto: "igrigorik@gmail.com",
-      company: "Google Inc.",
-      companyURL: "https://google.com/",
-      w3cid: "56102"
-    },
-    ],
-    formerEditors: [{
-      name: 'Arvind Jain',
-      company: 'Google Inc.',
-      companyURL: 'https://google.com/',
-      note: "Until December 2014"
-    }, {
-      name: 'Jatinder Mann',
-      company: 'Microsoft Corp.',
-      companyURL: 'https://microsoft.com',
-      note: "Until February 2014"
-    },
-    ],
-    edDraftURI: 'https://w3c.github.io/page-visibility/',
-    wg: 'Web Performance Working Group',
-    wgURI: 'https://www.w3.org/webperf/',
-    wgPublicList: 'public-web-perf',
-    wgPatentURI: 'https://www.w3.org/2004/01/pp-impl/45211/status',
-    noLegacyStyle: true,
-    github: "https://github.com/w3c/page-visibility/",
-    wgPublicList: "public-web-perf",
-    implementationReportURI: "https://wpt.fyi/page-visibility/",
-    testSuiteURI: "https://w3c-test.org/page-visibility/",
-    xref: 'web-platform'
+      specStatus: 'ED',
+      shortName: 'page-visibility-2',
+      editors: [{
+        name: "Ilya Grigorik",
+        url: "https://www.igvita.com/",
+        mailto: "igrigorik@gmail.com",
+        company: "Google Inc.",
+        companyURL: "https://google.com/",
+        w3cid: "56102"
+      },{
+        name: 'Arvind Jain',
+        company: 'Google Inc.',
+        companyURL: 'https://google.com/',
+        retired: "2014-12-01"
+      }, {
+        name: 'Jatinder Mann',
+        company: 'Microsoft Corp.',
+        companyURL: 'https://microsoft.com',
+        retired: "2014-02-01"
+      }],
+      wg: 'Web Performance Working Group',
+      wgURI: 'https://www.w3.org/webperf/',
+      wgPatentURI: 'https://www.w3.org/2004/01/pp-impl/45211/status',
+      github: "w3c/page-visibility",
+      wgPublicList: "public-web-perf",
+      implementationReportURI: "https://wpt.fyi/page-visibility/",
+      testSuiteURI: "https://w3c-test.org/page-visibility/",
+      xref: "web-platform"
     };
     </script>
   </head>
@@ -77,9 +71,8 @@
             </li>
           </ul>
         </li>
-        <li>
-          <a>Visibility state</a> is set to <a>hidden</a> when the user agent
-          is unloading a document;
+        <li>[=Document/Visibility state=] is set to [=hidden=] when the user
+        agent is unloading a document;
         </li>
       </ul>
     </section>
@@ -89,22 +82,22 @@
       </h2>
       <p>
         The <cite>Page Visibility API</cite> defines a means to
-        programmatically determine the <a>visibility state</a> of the <a>top-level
-        browsing context</a>, and to be notified if the <a>visibility state</a>
-        changes. Without knowing the <a>visibility state</a> of a page, web
-        developers have been designing web pages as if they are always
-        <a>visible</a>. This not only results in higher machine resource
-        utilization, but it prevents web developers from making runtime
-        decisions based on whether the web page is <a>visible</a> to the user.
-        Designing web pages with knowledge of the page's <a>visibility
-        state</a> can result in improved user experiences and power efficient
-        sites.
+        programmatically determine the [=Document/visibility state=] of a
+        top-level browsing context, and to be notified if the
+        [=Document/visibility state=] changes. Without knowing the
+        [=Document/visibility state=] of a page, web developers have been
+        designing web pages as if they are always [=Document/visible=]. This
+        not only results in higher machine resource utilization, but it
+        prevents web developers from making runtime decisions based on whether
+        the web page is [=Document/visible=] to the user. Designing web pages
+        with knowledge of the document's [=Document/visibility state=] can
+        result in improved user experiences and power efficient sites.
       </p>
       <p>
         With this API, web applications can choose to alter their behavior
-        based on whether they are <a>visible</a> to the user or not. For
+        based on whether they are [=Document/visible=] to the user or not. For
         example, this API can be used to scale back work when the page is no
-        longer <a>visible</a>.
+        longer [=Document/visible=].
       </p>
     </section>
     <section class='informative' data-link-for="VisibilityState">
@@ -114,7 +107,7 @@
       <p>
         To improve the user experience and optimize CPU and power efficiency
         the application could autoplay a video when the application is
-        <a>visible</a>, and automatically pause the playback when the
+        [=Document/visible=], and automatically pause the playback when the
         application is <a>hidden</a>:
       </p>
       <pre class="example js" title="Visibility-aware video playback">
@@ -153,18 +146,20 @@
       </h2>
       <p>
         The {{Document}} of the <a>top-level browsing context</a> can be in one
-        of the following <dfn data-export="" data-lt=
-        "visibility state">visibility states</dfn>:
+        of the following <dfn data-dfn-for="Document" data-export="">visibility
+        states</dfn>:
       </p>
       <dl data-sort="">
         <dt>
-          <dfn data-export="">hidden</dfn>
+          <dfn data-dfn-for="Document" data-export="" data-dfn-type=
+          "dfn">hidden</dfn>
         </dt>
         <dd>
-          The {{Document}} is not <a>visible</a> at all on any screen.
+          The {{Document}} is not [=Document/visible=] at all on any screen.
         </dd>
         <dt>
-          <dfn data-export="">visible</dfn>
+          <dfn data-dfn-for="Document" data-export="" data-dfn-type=
+          "dfn">visible</dfn>
         </dt>
         <dd>
           The {{Document}} is at least partially visible on at least one
@@ -172,11 +167,11 @@
         </dd>
       </dl>
       <p>
-        The <a>visibility states</a> are reflected in the API via the
+        The [=Document/visibility states=] are reflected in the API via the
         {{VisibilityState}} enum.
       </p>
     </section>
-    <section data-dfn-for="VisibilityState" data-link-for="VisibilityState">
+    <section data-dfn-for="VisibilityState">
       <h2>
         <code>VisibilityState</code> enum
       </h2>
@@ -187,13 +182,13 @@
       </pre>
       <p>
         The <dfn>VisibilityState</dfn> enum is used to represent the
-        <a>visibility states</a>.
+        [=Document/visibility states=].
       </p>
       <p>
-        The "<dfn>hidden</dfn>" enum value represents the <a data-link-for=
-        "">hidden</a> <a>visibility state</a>. Likewise, the
-        "<dfn>visible</dfn>" enum value represents the <a data-link-for=
-        "">visible</a> <a>visibility state</a>.
+        The "<dfn>hidden</dfn>" enum value represents the [=Document/hidden=]
+        [=Document/visibility state=]. Likewise, the "<dfn>visible</dfn>" enum
+        value represents the [=Document/visible=] [=Document/visibility
+        state=].
       </p>
     </section>
     <section data-dfn-for="Document">
@@ -220,14 +215,14 @@
         </p>
         <ol data-link-for="VisibilityState" class="algorithm">
           <li>If <a>steps to determine the visibility state</a> return
-          <a>visible</a>, then return <code>false</code>.
+          [=Document/visible=], then return <code>false</code>.
           </li>
           <li>Otherwise, return <code>true</code>.
           </li>
         </ol>
         <p class="note">
           Support for <a>hidden</a> attribute is maintained for historical
-          reasons. Developers should use <a>visibilityState</a> where possible.
+          reasons. Developers should use {{visibilityState}} where possible.
         </p>
       </section>
       <section data-dfn-for="Document" data-link-for="Document">
@@ -235,15 +230,15 @@
           <dfn>visibilityState</dfn> attribute
         </h3>
         <p>
-          On getting, the <a>visibilityState</a> attribute the user agent MUST
-          run the <dfn>steps to determine the visibility state</dfn>:
+          On getting, the {{visibilityState}} attribute the user agent MUST run
+          the <dfn>steps to determine the visibility state</dfn>:
         </p>
         <ol class="algorithm">
           <li>Return "hidden" if the <a>context object</a> is not [=Document/fully active=]</li>
           <li>Let |doc:Document| be the <a>active document</a> of the top level
           browsing context of the <a>context object</a>'s [=Document/browsing context=].</li>
           <li>Otherwise, return the {{VisibilityState}} value that best matches
-          the <a>visibility state</a> of |doc|:
+          the [=Document/visibility state=] of |doc|:
             <ol>
               <li>Return {{VisibilityState["visible"]}} if:
                 <ol>
@@ -304,7 +299,7 @@
         <li>Let |doc:Document| be the {{Document}} of the <a>top-level browsing
         context</a>.
         </li>
-        <li>If |doc| is now <a>visible</a>:
+        <li>If |doc| is now [=Document/visible=]:
           <ol>
             <li>If traversing to a <a>session history entry</a>, run the <a>now
             visible algorithm</a> before running the step to fire the
@@ -315,8 +310,8 @@
             </li>
           </ol>
         </li>
-        <li>Else if |doc| is now not <a>visible</a>, or if the user agent is to
-        [=Window/unload=] |doc|:
+        <li>Else if |doc| is now not [=Document/visible=], or if the user agent
+        is to [=Window/unload=] |doc|:
           <ol>
             <li>If the user agent is to [=Window/unload=] the {{Document}}, run
             the <a>now hidden algorithm</a> during the <a>unloading document

--- a/index.html
+++ b/index.html
@@ -146,8 +146,8 @@
       </h2>
       <p>
         The {{Document}} of the <a>top-level browsing context</a> can be in one
-        of the following <dfn data-dfn-for="Document" data-export="" data-lt="visibility state">visibility
-        states</dfn>:
+        of the following <dfn data-dfn-for="Document" data-export="" data-lt=
+        "visibility state">visibility states</dfn>:
       </p>
       <dl data-sort="">
         <dt>
@@ -234,41 +234,59 @@
           the <dfn>steps to determine the visibility state</dfn>:
         </p>
         <ol class="algorithm">
-          <li>Return "hidden" if the <a>context object</a> is not [=Document/fully active=]</li>
+          <li>Return "hidden" if the <a>context object</a> is not
+          [=Document/fully active=]
+          </li>
           <li>Let |doc:Document| be the <a>active document</a> of the top level
-          browsing context of the <a>context object</a>'s [=Document/browsing context=].</li>
+          browsing context of the <a>context object</a>'s [=Document/browsing
+          context=].
+          </li>
           <li>Otherwise, return the {{VisibilityState}} value that best matches
           the [=Document/visibility state=] of |doc|:
             <ol>
               <li>Return {{VisibilityState["visible"]}} if:
                 <ol>
-                  <li>The user agent has a screen reader attached to the |doc|</li>
-                  <li>Any of the |doc|'s viewport contents are observable to the user</li>
+                  <li>The user agent has a screen reader attached to the |doc|
+                  </li>
+                  <li>Any of the |doc|'s viewport contents are observable to
+                  the user
+                  </li>
                 </ol>
               </li>
               <li>Return {{VisibilityState["hidden"]}} if:
                 <ol>
-                  <li>The user agent is to [=Window/unload=] |doc|</li>
-                  <li>The |doc|'s viewport contents are not observable to the user</li>
+                  <li>The user agent is to [=Window/unload=] |doc|
+                  </li>
+                  <li>The |doc|'s viewport contents are not observable to the
+                  user
+                  </li>
                 </ol>
               </li>
             </ol>
           </li>
         </ol>
         <div class="note">
-        <p>
-          To accommodate assistive technologies that are typically full screen
-          but still show a view of the page, when applicable, on getting, the
-          {{Document/visibilityState}} attribute MAY return
-          {{VisibilityState["visible"]}}, instead of {{VisibilityState["hidden"]}}, when the user agent is
-          not minimized but is fully obscured by other applications.
           <p>
-          Examples of ways that {{VisibilityState["hidden"]}} may be returned:
+            To accommodate assistive technologies that are typically full
+            screen but still show a view of the page, when applicable, on
+            getting, the {{Document/visibilityState}} attribute MAY return
+            {{VisibilityState["visible"]}}, instead of
+            {{VisibilityState["hidden"]}}, when the user agent is not minimized
+            but is fully obscured by other applications.
+          </p>
+          <p>
+            Examples of ways that {{VisibilityState["hidden"]}} may be
+            returned:
+          </p>
           <ul>
-          <li>A tab is made into a background tab</li>
-          <li>The user agent is minimized</li>
-          <li>The user agent is moved off of the screen</li>
-          <li>The operating system's lock screen covers the user agent</li>
+            <li>A tab is made into a background tab
+            </li>
+            <li>The user agent is minimized
+            </li>
+            <li>The user agent is moved off of the screen
+            </li>
+            <li>The operating system's lock screen covers the user agent
+            </li>
           </ul>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -410,6 +410,7 @@
     <section id="conformance">
       <!-- autofilled by respec -->
     </section>
+    <section id="index" class="appendix"></section>
     <section id="acknowledgements" class="appendix">
       <h2>
         Acknowledgments

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
       </h2>
       <p>
         The {{Document}} of the <a>top-level browsing context</a> can be in one
-        of the following <dfn data-dfn-for="Document" data-export="">visibility
+        of the following <dfn data-dfn-for="Document" data-export="" data-lt="visibility state">visibility
         states</dfn>:
       </p>
       <dl data-sort="">


### PR DESCRIPTION
Don't merge yet! Working on ReSpec support for this. 

This will allow other ReSpec/BikeShed specifications reference the "visible", "hidden", and "visibility states" concepts, by doing: 

  * `[=Document/visibility state=]`
  * `[=Document/hidden=]`
  * `[=Document/visible=]`

This is important for other specs, like Screen Orientation, that depend heavily on being able to check visibility state of a Document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/page-visibility/pull/54.html" title="Last updated on May 19, 2020, 2:26 PM UTC (9cc4b8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/page-visibility/54/0c5325a...9cc4b8a.html" title="Last updated on May 19, 2020, 2:26 PM UTC (9cc4b8a)">Diff</a>