### PR TITLE
chore: Export the "external now hidden algorithm" definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,8 +374,8 @@
           <a>Fire an event</a> named "`visibilitychange`" that bubbles, isn't
           cancelable, and has no default action, at the |doc|.
         </li>
-        <li>Run <dfn>external now hidden algorithm</dfn> if one is defined by
-        another specification.
+        <li>Run <dfn data-export="">external now hidden algorithm</dfn> if one
+        is defined by another specification.
         </li>
       </ol>
     </section>


### PR DESCRIPTION
This was added in #47 but not exported. Commit 730b632aa ("chore: export
'external now visible algorithm'") exported the "external now visible
algorithm" definition but left this one out.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/page-visibility/pull/72.html" title="Last updated on Jun 4, 2021, 11:19 AM UTC (3038c44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/page-visibility/72/311eaf5...rakuco:3038c44.html" title="Last updated on Jun 4, 2021, 11:19 AM UTC (3038c44)">Diff</a>